### PR TITLE
Fix  MPMoPubNativeAdAdapter.m crash

### DIFF
--- a/MoPubSDK/NativeAds/Internal/MPMoPubNativeAdAdapter.m
+++ b/MoPubSDK/NativeAds/Internal/MPMoPubNativeAdAdapter.m
@@ -80,7 +80,12 @@ static const CGFloat kMoPubRequiredViewVisibilityPercentage = 0.5;
             valid = NO;
         }
 
-        _defaultActionURL = [NSURL URLWithString:[properties objectForKey:kDefaultActionURLKey]];
+        // Validate that the clickthrough URL is a string before attempting to parse into a URL
+         id clickthroughUrl = [properties objectForKey:kDefaultActionURLKey];
+         if ([clickthroughUrl isKindOfClass:[NSString class]]) {
+             NSString *clickthroughUrlString = (NSString *)clickthroughUrl;
+             _defaultActionURL = [NSURL URLWithString:clickthroughUrlString];
+         }
 
         // Grab the config, figure out requiredSecondsForImpression and requiredViewVisibilityPercentage,
         // and set up the timer.

--- a/MoPubSDKTests/MPMoPubNativeAdAdapterTests.m
+++ b/MoPubSDKTests/MPMoPubNativeAdAdapterTests.m
@@ -21,6 +21,27 @@
 
 @implementation MPMoPubNativeAdAdapterTests
 
+#pragma mark - Initialization
+
+ - (void)testNSNullClickthroughShouldNotParse {
+     NSMutableDictionary * properties = [MPAdConfigurationFactory defaultNativeProperties];
+     properties[kDefaultActionURLKey] = NSNull.null;
+
+     MPMoPubNativeAdAdapter * adapter = [[MPMoPubNativeAdAdapter alloc] initWithAdProperties:properties];
+     XCTAssertNotNil(adapter);
+     XCTAssertNil(adapter.defaultActionURL);
+ }
+
+ - (void)testStringClickthroughShouldParse {
+     NSMutableDictionary * properties = [MPAdConfigurationFactory defaultNativeProperties];
+     properties[kDefaultActionURLKey] = @"https://www.mopub.com";
+
+     MPMoPubNativeAdAdapter * adapter = [[MPMoPubNativeAdAdapter alloc] initWithAdProperties:properties];
+     XCTAssertNotNil(adapter);
+     XCTAssertNotNil(adapter.defaultActionURL);
+     XCTAssert([adapter.defaultActionURL.absoluteString isEqualToString:@"https://www.mopub.com"]);
+ }
+
 #pragma mark - Privacy Icon Overrides
 
 - (void)testPrivacyIconNoOverrideSuccess {


### PR DESCRIPTION
I glanced over the diff of MoPub version 5.13.0 which - even though it's not mentioned - looks to have fixed the crash we're currently experiencing. This is my best educated guess on what to pick from those thousands of lines but it seems promising 😅

We're not just simply updating the whole thing due to adapter dependencies.